### PR TITLE
Fix single-line comments

### DIFF
--- a/src/minipack.js
+++ b/src/minipack.js
@@ -191,7 +191,9 @@ function bundle(graph) {
     // be able to know which module in the graph corresponds to that relative
     // path for this module.
     modules += `${mod.id}: [
-      function (require, module, exports) { ${mod.code} },
+      function (require, module, exports) {
+        ${mod.code}
+      },
       ${JSON.stringify(mod.mapping)},
     ],`;
   });


### PR DESCRIPTION
Having a single-line comment at the end of a module breaks the bundle.