### PR TITLE
Asset Caching to Avoid Redundant Parsing

### DIFF
--- a/src/minipack.js
+++ b/src/minipack.js
@@ -88,13 +88,17 @@ function createAsset(filename) {
   });
 
   // Return all information about this module.
-  return {
+  const asset = {
     id,
     filename,
     dependencies,
     code,
   };
-}
+
+// NEW: cache the asset
+ assetCache[absolutePath] = asset;
+  
+  return asset;
 
 // Now that we can extract the dependencies of a single module, we are going to
 // start by extracting the dependencies of the entry file.


### PR DESCRIPTION
Parsing a file and building its AST is expensive and deterministic. If the same file is requested again, we should reuse the result instead of recomputing it.