### PR TITLE
Establishing Stable Module Identity Using Absolute Paths

### DIFF
--- a/src/minipack.js
+++ b/src/minipack.js
@@ -131,7 +131,7 @@ function createGraph(entry) {
       // relative to the file that imported them. We can turn the relative path
       // into an absolute one by joining it with the path to the directory of
       // the parent asset.
-      const absolutePath = path.join(dirname, relativePath);
+      const absolutePath = path.resolve(dirname, relativePath);
 
       // Parse the asset, read its content, and extract its dependencies.
       const child = createAsset(absolutePath);


### PR DESCRIPTION
same file so same absolute path
cache works correctly

resolving every module path to an absolute path before creating an asset, the bundler establishes a stable identity for each file in the dependency graph. Different relative import paths that reference the same file are normalized to a single absolute path, ensuring that the cache consistently returns the same asset instance. This prevents duplicate parsing, guarantees that each module receives a single unique ID, and allows all import edges in the graph to correctly point to the same node.